### PR TITLE
test: Admin Application pet approve/reject doesn't affect other apps

### DIFF
--- a/spec/features/admin/application/show_spec.rb
+++ b/spec/features/admin/application/show_spec.rb
@@ -26,4 +26,36 @@ RSpec.describe "admin/application show page" do
       expect(page).to have_content("#{@pet1.name} has been rejected \u{1F622}")
     end
   end
+
+  describe 'User Story 14' do
+    it 'can approve a pet on one app and not affect the same pet on another app' do
+      visit "/admin/applications/#{@app2.id}"
+
+      click_on "Approve #{@pet3.name}"
+
+      expect(current_path).to eq("/admin/applications/#{@app2.id}")
+      expect(page).to have_content("#{@pet3.name} has been approved!")
+
+      visit "/admin/applications/#{@app4.id}"
+
+      expect(page).to_not have_content("#{@pet3.name} has been approved!")
+      expect(page).to have_button("Approve #{@pet3.name}")
+      expect(page).to have_button("Reject #{@pet3.name}")
+    end
+
+    it 'can reject a pet on one app and not affect the same pet on another app' do
+      visit "/admin/applications/#{@app2.id}"
+
+      click_on "Reject #{@pet3.name}"
+
+      expect(current_path).to eq("/admin/applications/#{@app2.id}")
+      expect(page).to have_content("#{@pet3.name} has been rejected \u{1F622}")
+
+      visit "/admin/applications/#{@app4.id}"
+
+      expect(page).to_not have_content("#{@pet3.name} has been rejected \u{1F622}")
+      expect(page).to have_button("Approve #{@pet3.name}")
+      expect(page).to have_button("Reject #{@pet3.name}")
+    end
+  end
 end


### PR DESCRIPTION
### Describe your changes
- create tests for User Story 14
  - approving a pet on one app does not affect another app
  - rejecting a pet on one app does not affect another app

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] I have added thorough tests - unit and integrated.
